### PR TITLE
Fix bug in if() when used in a surrounding expression

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -99,7 +99,7 @@ export default function(codegen) {
         if (args.length < 3) error('Missing arguments to if function.');
         if (args.length > 3) error('Too many arguments to if function.');
         var a = args.map(codegen);
-        return a[0]+'?'+a[1]+':'+a[2];
+        return '('+a[0]+'?'+a[1]+':'+a[2]+')';
       }
   };
 }

--- a/test/codegen-test.js
+++ b/test/codegen-test.js
@@ -257,6 +257,9 @@ tape('Evaluate expressions with white list', function(test) {
   test.throws(evaluate.fn('if(datum.a > 1, 1)'));
   test.throws(evaluate.fn('if(datum.a > 1, 1, 2, 3)'));
 
+  // "if" should be isolated from surrounding expression
+  test.equal(evaluate('0 * if(datum.a > 1, 1, 2)'), 0);
+
   // should not eval undefined functions
   test.throws(evaluate.fn('Array()'));
   test.throws(evaluate.fn('Function()'));


### PR DESCRIPTION
See the commit messages for more details.

This branch is from master, but the v1.x branch is also affected.  I noticed the bug while working with a Vega 2 spec.  Backporting it should just be a matter of `git cherry-pick`, and I'd be happy to do that if it'll get included in a subsequent Vega 2 bugfix release.